### PR TITLE
Fix links in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="index.html"><strong>PrismarineJS</strong></a>
+                <a class="navbar-brand" href="/"><strong>PrismarineJS</strong></a>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -50,10 +50,10 @@
                         <a href="http://prismarinejs.github.io/Download/">Download</a>
                     </li>
                     <li>
-                        <a href="#Team">The Team</a>
+                        <a href="/#Team">The Team</a>
                     </li>
                     <li>
-                        <a href="#FAQ">What is PrismarineJS</a>
+                        <a href="/#FAQ">What is PrismarineJS</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Previously, if open `Downloads` page, `index`, `FAQ` and `Team` links will point to `/Download/` path.